### PR TITLE
Simplify proposal, specify eager evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Partial Application Syntax for ECMAScript
 
-This proposal introduces a new syntax using the `?` and `...` tokens which allows you to partially apply an argument list to 
-a call expression by acting as placeholders for an argument or arguments.
+This proposal introduces a new syntax using the `?` token in an argument list which allows you to 
+partially apply an argument list to a call expression by acting as a placeholder for an argument.
 
 ## Status
 
@@ -17,8 +17,8 @@ _For more information see the [TC39 proposal process](https://tc39.github.io/pro
 # Proposal
 
 Partial function application allows you to fix a number of arguments to a function call, returning
-a new function. Partial application is supported after a fashion in ECMAScript today through the use of either 
-`Function#bind` or arrow functions:
+a new function. Partial application is supported after a fashion in ECMAScript today through the 
+use of either `Function#bind` or arrow functions:
 
 ```js
 function add(x, y) { return x + y; }
@@ -47,7 +47,7 @@ However, there are several of limitations with these approaches:
     is harder to debug.
 
 To resolve these concerns, we propose leveraging the `?` token to act as an "argument placeholder" 
-for a non-fixed argument, and the `...` token to act as a "remaining arguments placeholder":
+for a non-fixed argument:
 
 ```js
 const addOne = add(1, ?); // apply from the left
@@ -60,194 +60,86 @@ addTen(2); // 12
 let newScore = player.score
   |> add(7, ?)
   |> clamp(0, 100, ?); // shallow stack, the pipe to `clamp` is the same frame as the pipe to `add`.
-
-const maxGreaterThanZero = Math.max(0, ...);
-maxGreaterThanZero(1, 2); // 2
-maxGreaterThanZero(-1, -2); // 0
 ```
 
 # Syntax
 
+The `?` placeholder token can be supplied one or more times at the top level of the _Arguments_ of 
+a _CallExpression_, _CallMemberExpression_, or _SuperCall_ (e.g. `f(?)` or `o.f(?)`). `?` is **not**
+an expression, rather it is a syntactic element of an _ArgumentList_ that indicates special behavior
+(much like how `` `...` AssignmentExpression `` indicates spread, yet is itself not an expression). 
+
 ```js
+// valid
 f(x, ?)           // partial application from left
-f(x, ...)         // partial application from left with rest
 f(?, x)           // partial application from right
-f(..., x)         // partial application from right with rest
 f(?, x, ?)        // partial application for any arg
-f(..., x, ...)    // partial application for any arg with rest
+o.f(x, ?)         // partial application from left
+o.f(?, x)         // partial application from right
+o.f(?, x, ?)      // partial application for any arg
+
+// invalid
+f(x + ?)          // `?` not in top-level Arguments of call
+x + ?             // `?` not in top-level Arguments of call
+?.f()             // `?` not in top-level Arguments of call
+new f(?)          // `?` not supported in `new`
 ```
 
 # Semantics
 
-The `?` and `...` placeholder tokens can only be used in an argument list of a call expression. When present, 
-the result of the call is a new function with a parameter for each `?` token in the argument list. Any excess
-parameters are spread into the call at the position of the `...` token. Any non-placeholder expression in the 
-argument list becomes fixed in its position. This is illustrated by the following syntactic conversion:
+The `?` placeholder token can only be used in an argument list of a call expression. When present, 
+the result of the call is a new function with a parameter for each `?` token in the argument list. 
+Any non-placeholder expression in the argument list becomes fixed in its position. This is 
+illustrated by the following syntactic conversion:
 
 ```js
-const g = f(?, 1, ...)
+const g = f(?, 1, ?);
 ```
 
 is roughly identical in its behavior to:
 
 ```js
-const g = (x, ...y) => f(x, 1, ...y);
+const $$temp0 = f, $$temp1 = 1;
+const g = (_0, _1) => $$temp0(_0, $$temp1, _1);
 ```
 
-However, this is a somewhat trivial example. Partial application in this fashion has the following
-semantic rules:
+In addition to fixing the function to be called and its explicit arguments, we also fix any 
+supplied _receiver_ as part of the resulting function. As such, `o.f(?)` will maintain `o` as the 
+`this` receiver when calling `o.f`. This can be illustrated by the following syntactic conversion:
 
-* Given `f(?)`, the expression `f` is not evaluated immediately. Side effects that replace `f` 
-  can be observed with successive calls to the resulting function:
-  ```js
-  let f = (x, y) => x + y;
+```js
+const g = o.f(?, 1);
+```
 
-  const g = f(?, 3);
-  g(1); // 4
+is roughly identical in its behavior to:
 
-  // replace the value of `f`
-  f = (x, y) => x * y;
+```js
+const $$temp0 = o, $$temp1 = $$temp0.f, $$temp2 = 1;
+const g = (_0) => $$temp1.call($$temp0, _0, $$temp2);
+```
 
-  g(1); // 3
-  ```
-* Given `o.f(?)`, the references to `o` and `o.f` are not evaluated immediately. Side effects that 
-  replace `o` or `o.f` can be observed with successive calls to the resulting function:
-  ```js
-  let o = { f(x, y) { return x + y + this.z; }, z: 0 };
-  
-  const g = o.f(?, 3);
-  g(1); // 4
+In both of the above examples, excess supplied arguments to `g` are ignored and **not** passed on 
+to the partially applied function. The ability to pass on additional arguments is not part of this
+proposal but may be considered in a future proposal.
 
-  // replace the value of `o`
-  o = { f(x, y) { return x + y + this.z; }, z: 2 };
-  g(1); // 6
+The following is a list of additional semantic rules:
 
-  // replace the value of `o.f`
-  o.f = (x, y) => x * y;
-  g(1); // 5
-  ```
-  Note that this also means that more involved references are captured in their entirety and should be
-  stored in a local variable if they may have unintended side-effects should the partially applied 
-  function result be called more than once:
-  ```js
-  const a = [{ c: x => x + 1 }, { c: x => x + 2 }];
-  let b = 0;
-  const g = a[b++].c(?);
-  b; // 0
-  g(1); // 2
-  g(1); // 3
-  b; // 2
-
-  // vs
-
-  const a = [{ c: x => x + 1 }, { c: x => x + 2 }];
-  let b = 0;
-  const o = a[b++];
-  const g = o.c(?);
-  b; // 1
-  g(1); // 2
-  g(1); // 2
-  b; // 1
-  ```
-* Given `f(?)`, while the non-placeholder arguments to `f` are fixed in their positions, they are not 
-  evaluated immediately. Side effects that mutate references in these arguments can be observed with 
-  successive calls to the resulting function:
-  ```js
-  let a = 3;
-  const f = (x, y) => x + y;
-
-  const g = f(?, a);
-  g(1); // 4
-
-  // replace the value of `a`
-  a = 10;
-
-  g(1); // 11
-  ```
-* Given `g = f(?)`, excess arguments supplied to the partially applied function result `g` are ignored:
-  ```js
-  const f = (x, ...y) => [x, ...y];
-  const g = f(?, 1);
-  g(2, 3, 4); // [2, 1]
-  ```
-* Given `g = f(?, ?)` the partially applied function result `g` will have a 
-  parameter for each placeholder token that is supplied in that token's position in the 
-  argument list:
-  ```js
-  const f = (x, y, z) => [x, y, z];
-  const g = f(?, 4, ?);
-  g(1, 2); // [1, 4, 2]
-  ```
-* Given `g = f(...)`, excess arguments supplied to the partially applied function result `g` are spread 
-  into the original function at the indicated position:
-  ```js
-  const f = (x, ...y) => [x, ...y];
-  const g = f(?, 1, ...);
-  g(2, 3, 4); // [2, 1, 3, 4];
-  ```
-* Given `g = f(..., ...)`, the excess arguments supplied to the partially 
-  applied function result `g` are collected **once** but are spread into the call once for each 
-  position:
-  ```js
-  const f = (...x) => x;
-  const g = f(..., 9, ...);
-  g(1, 2, 3); // [1, 2, 3, 9, 1, 2, 3]
-  ```
-* Given `f(this, ?)`, the `this` in the argument list is the lexical `this`:
-  ```js
-  const fader = {
-      color: "#00ffff",
-      async fade() {
-        const fadeOut = desaturate(this.color, ?); // capture lexical `this` here.
-        for (let i = 100; i > 0; i -= 10) {
-            fadeOut(i);
-            await delay(10);
-        }
-      }
-  }
-  ```
-* Given `g = f(?)`, the `this` receiver of the function `f` is fixed as `undefined` in the partially
-  applied function result `g`:
-  ```js
-  function f(x) { return `this: ${this}, x: ${x}`; }
-  const o = { g: f(?) };
-  o.g(2); // 'this: undefined, x: 2'
-  ```
-  However, you may uncurry `this` using `f.call`:
-  ```js
-  function f(x) { return `this: ${this}, x: ${x}.`; }
-  const g = f.call(?, 2);
-  g(1, 2); // `this: 1, x: 2`
-  ```
-* Given `g = o.f(?)`, the `this` receiver of the function `o.f` is fixed as `o` in the partially 
-  applied function result `g`:
-  ```js
-  const o = { f(x) { return `this.y: ${this.y}, x: ${x}`; }, y: 1 };
-  const g = o.f(?);
-  g(2); // 'this.y: 1, x: 2'
-  ```
-  However, you may uncurry `this` using `o.f.call`:
-  ```js
-  const o = { f(x) { return `this.y: ${this.y}, x: ${x}`; }, y: 1 };
-  const g = o.f.call(?, 3);
-  g({ y: 4 }); // 'this.y: 4, x: 3'
-  ```
-* Given `g = new f(?)`, the partially applied function result `g` is a function that when called will 
-  construct a new instance of `f`:
-  ```js
-  function f(x, y) { this.z = `${x}, ${y}` }
-  const g = new f("a", ?);
-  const obj = g(1); // creates an f instance
-  obj.z; // 'a, 1'
-  ```
-* Given `g = f(?)`, the `length` of the partially applied function result `g` is equal to the number of `?` placeholder tokens in the
-  argument list:
-  ```js
-  const f = (x, y) => x + y;
-  const g = f(?, 2);
-  f.length; // 2
-  g.length; // 1
-  ```
+* Given `f(?)`, the expression `f` is evaluated immediately.
+* Given `f(?, x)`, the non-placeholder argument `x` is evaluated immediately and fixed in its position.
+* Given `f(?)`, excess arguments supplied to the partially applied function result are ignored.
+* Given `f(?, ?)` the partially applied function result will have a parameter for each placeholder 
+  token that is supplied in that token's position in the argument list.
+* Given `f(this, ?)`, the `this` in the argument list is the lexical `this`.
+* Given `f(?)`, the `this` receiver of the function `f` is fixed as `undefined` in the partially
+  applied function result.
+* Given `f(?)`, the `length` of the partially applied function result is equal to the number of `?` placeholder tokens in the
+  argument list.
+* Given `f(?)`, the `name` of the partially applied function result is `f.name`.
+* Given `o.f(?)`, the references to `o` and `o.f` are evaluated immediately.
+* Given `o.f(?)`, the `this` receiver of the function `o.f` is fixed as `o` in the partially 
+  applied function result.
+* Given `f(g(?))`, this is roughly equivalent to `f(_0 => g(_0))` **not** `_0 => f(g(_0))`. This 
+  is because the `?` is directly part of the argument list of `g` and not the argument list of `f`.
 
 ## Pipeline and Partial Application
 
@@ -283,14 +175,8 @@ const res = a |> f(?, 1) |> g(?, 2);
 is approximately identical to:
 
 ```js
-const res = g(f(a, 1), 2);
-```
-
-though a more accurate conversion would be:
-
-```js
-let _temp;
-const (_temp = a, _temp = f(_temp, 1), g(_temp, 2));
+let $$temp;
+const res = ($$temp = a, $$temp = f($$temp, 1), g($$temp, 2));
 ```
 
 # Parsing
@@ -303,35 +189,29 @@ while `f(?` is definitely a placeholder).
 # Grammar
 
 ```grammarkdown
-ArgumentList[Yield, Await]:
-  `?`
-  AssignmentExpression[+In, ?Yield, ?Await]
-  `...` AssignmentExpression[+In, ?Yield, ?Await]?
-  ArgumentList[?Yield, ?Await] `,` `?`
-  ArgumentList[?Yield, ?Await] `,` AssignmentExpression[+In, ?Yield, ?Await]
-  ArgumentList[?Yield, ?Await] `,` `...` AssignmentExpression[+In, ?Yield, ?Await]?
+MemberExpression[Yield, Await] :
+  `new` MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await, +New]
+
+CallExpression[Yield, Await] :
+  CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await, ~New]
+
+CoverCallExpressionAndAsyncArrowHead[Yield, Await]:
+  MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await, ~New]
+
+CallMemberExpression[Yield, Await] :
+  MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await, ~New]
+
+SuperCall[Yield, Await] :
+  `super` Arguments[?Yield, ?Await, ~New]
+
+Arguments[Yield, Await, New] :
+  `(` ArgumentList[?Yield, ?Await, ?New] `)`
+  `(` ArgumentList[?Yield, ?Await, ?New], `,` `)`
+
+ArgumentList[Yield, Await, New] :
+  [~New] `?`
+  [~New] ArgumentList[?Yield, ?Await, ~New] `,` `?`
 ```
-
-<!--
-# Out of Scope/Future Directions
-
-There are several additional features that are currently out of scope for this proposal, but may be 
-considered in future proposals or added to this proposal if there is a valid reason to do so:
-
-* Positional placeholders:
-  ```js
-  f(?1, ?0)         // roughly: (x, y) => f(y, x)
-  ```
-* Spread a placeholder *without* rest:
-  ```js
-  f(1, ...?, 2)     // roughly: (x) => f(1, ...x, 2)
-  ```
-* Default initializers (similar to initializers/defaults for parameters, destructuring, and 
-  binding patterns):
-  ```js
-  f(? = 1, 2)       // roughly: (x = 1) => f(x, 2)
-  ```
--->
 
 # Resources
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "6.0.84",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-      "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg==",
-      "dev": true
-    },
     "abab": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
     "abbrev": {
@@ -23,36 +17,31 @@
       "dev": true
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "5.7.1"
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true,
-      "optional": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -73,9 +62,9 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
@@ -154,9 +143,15 @@
       "dev": true
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -166,15 +161,15 @@
       "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "balanced-match": {
@@ -184,9 +179,9 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -200,9 +195,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "body-parser": {
@@ -240,15 +235,6 @@
         }
       }
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -269,6 +255,12 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
     },
     "bytes": {
       "version": "2.4.0",
@@ -314,9 +306,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
@@ -363,31 +355,16 @@
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
       "dev": true
     },
-    "content-type-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
-      }
-    },
     "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
       "dev": true
     },
     "cssstyle": {
@@ -396,7 +373,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.4"
       }
     },
     "dashdash": {
@@ -406,14 +383,17 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
+      }
+    },
+    "data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.5.0"
       }
     },
     "dateformat": {
@@ -500,6 +480,15 @@
         "fs-exists-sync": "0.1.0"
       }
     },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -535,23 +524,31 @@
       }
     },
     "ecmarkup": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-3.11.5.tgz",
-      "integrity": "sha1-Vx3piTmVbHceYeAW9w/VuHr+Gj4=",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-3.16.0.tgz",
+      "integrity": "sha512-kG0i8Vy4TTDlvmsLyEWqqqrQH0Tiu3QcVsTFKrz82Wt8p8tdYh9RcVEamZa2CX3zA8yOj2zQLMCcDqzL5g3U0w==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "chalk": "1.1.3",
         "ecmarkdown": "3.0.9",
-        "grammarkdown": "1.0.7",
+        "grammarkdown": "2.0.11",
         "he": "1.1.1",
         "highlight.js": "9.12.0",
         "html-escape": "1.0.2",
-        "js-yaml": "3.9.0",
-        "jsdom": "11.1.0",
+        "js-yaml": "3.12.0",
+        "jsdom": "11.10.0",
         "nomnom": "1.8.1",
-        "prex": "0.2.0",
+        "prex": "0.4.2",
         "promise-debounce": "1.0.1"
+      },
+      "dependencies": {
+        "prex": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/prex/-/prex-0.4.2.tgz",
+          "integrity": "sha512-TZhR8PdeMRoLo2DzmaG/9uc21oda84O9H4eyKyESrJDYA443jd+acUnOXh3RsC0FCK+ro5e5jkzjcT0gEBF/IA==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -599,36 +596,36 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "estraverse": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -701,9 +698,9 @@
       }
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fancy-log": {
@@ -715,6 +712,18 @@
         "chalk": "1.1.3",
         "time-stamp": "1.1.0"
       }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -852,13 +861,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "mime-types": "2.1.15"
       }
     },
@@ -902,14 +911,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "glob": {
@@ -1129,12 +1130,20 @@
       }
     },
     "grammarkdown": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-1.0.7.tgz",
-      "integrity": "sha1-NxO5ybqk9XDztqyJpH36ALNGWxs=",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-2.0.11.tgz",
+      "integrity": "sha512-udzyhGg36U0yLEv3p5VAMAIx9LKtx+uYwkopu30SU0C7/GQKXNp3TxW6GKiZ6DWlju8rqDSkBstnulaF1Ss+4g==",
       "dev": true,
       "requires": {
-        "prex": "0.2.0"
+        "prex": "0.4.2"
+      },
+      "dependencies": {
+        "prex": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/prex/-/prex-0.4.2.tgz",
+          "integrity": "sha512-TZhR8PdeMRoLo2DzmaG/9uc21oda84O9H4eyKyESrJDYA443jd+acUnOXh3RsC0FCK+ro5e5jkzjcT0gEBF/IA==",
+          "dev": true
+        }
       }
     },
     "gulp": {
@@ -1228,19 +1237,19 @@
       }
     },
     "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -1267,18 +1276,6 @@
         "sparkles": "1.0.0"
       }
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -1291,12 +1288,6 @@
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
       "dev": true
     },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
-    },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -1307,12 +1298,12 @@
       }
     },
     "html-encoding-sniffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
-      "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.1"
+        "whatwg-encoding": "1.0.3"
       }
     },
     "html-escape": {
@@ -1334,20 +1325,20 @@
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "iconv-lite": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "inflight": {
@@ -1564,13 +1555,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-      "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -1581,32 +1572,37 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.1.0.tgz",
-      "integrity": "sha512-vKKDU+Xh9O6VgzdOYf5Rmqbgp+Yz4YTBC19gaLtctXch33EmNucA395KJGGboldafPW1vv9XLuiprO4+wXfl0g==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
+      "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
       "dev": true,
       "requires": {
-        "abab": "1.0.3",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
+        "abab": "1.0.4",
+        "acorn": "5.7.1",
+        "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
-        "content-type-parser": "1.0.1",
-        "cssom": "0.3.2",
+        "cssom": "0.3.4",
         "cssstyle": "0.2.37",
-        "escodegen": "1.8.1",
-        "html-encoding-sniffer": "1.0.1",
-        "nwmatcher": "1.4.1",
-        "parse5": "3.0.2",
-        "pn": "1.0.0",
-        "request": "2.81.0",
-        "request-promise-native": "1.0.4",
+        "data-urls": "1.0.0",
+        "domexception": "1.0.1",
+        "escodegen": "1.11.0",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.3.0",
+        "nwmatcher": "1.4.4",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
+        "request": "2.87.0",
+        "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.2",
-        "webidl-conversions": "4.0.1",
-        "whatwg-encoding": "1.0.1",
-        "whatwg-url": "6.1.0",
-        "xml-name-validator": "2.0.1"
+        "tough-cookie": "2.4.3",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.5.0",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
       }
     },
     "json-schema": {
@@ -1615,14 +1611,11 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1630,30 +1623,16 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
+        "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
-        "verror": "1.3.6"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
+        "verror": "1.10.0"
       }
     },
     "kind-of": {
@@ -1664,6 +1643,12 @@
       "requires": {
         "is-buffer": "1.1.5"
       }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -1693,9 +1678,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "lodash._basecopy": {
@@ -2023,9 +2008,9 @@
       }
     },
     "nwmatcher": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true
     },
     "oauth-sign": {
@@ -2173,13 +2158,10 @@
       "dev": true
     },
     "parse5": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
-      "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
-      "dev": true,
-      "requires": {
-        "@types/node": "6.0.84"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.1",
@@ -2230,9 +2212,9 @@
       }
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
@@ -2257,9 +2239,9 @@
       }
     },
     "pn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
-      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "prelude-ls": {
@@ -2298,10 +2280,16 @@
       "integrity": "sha1-btdvj3nQFE/b0BzBVYnOV/nXHng=",
       "dev": true
     },
+    "psl": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
+      "integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
+      "dev": true
+    },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "q": {
@@ -2438,33 +2426,69 @@
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        }
       }
     },
     "request-promise-core": {
@@ -2473,18 +2497,18 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "request-promise-native": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.4.tgz",
-      "integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
         "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.2"
+        "tough-cookie": "2.4.3"
       }
     },
     "resolve": {
@@ -2519,6 +2543,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "sax": {
@@ -2595,24 +2625,12 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "amdefine": "1.0.1"
-      }
+      "optional": true
     },
     "sparkles": {
       "version": "1.0.0",
@@ -2636,27 +2654,20 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
+        "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "statuses": {
@@ -2690,12 +2701,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
@@ -2821,19 +2826,31 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
+        "psl": "1.1.28",
         "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
       }
     },
     "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -2913,9 +2930,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "v8flags": {
@@ -2928,12 +2945,14 @@
       }
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "extsprintf": "1.0.2"
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
       }
     },
     "vinyl": {
@@ -3003,10 +3022,19 @@
         }
       }
     },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
+      }
+    },
     "webidl-conversions": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
-      "integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
     },
     "websocket-driver": {
@@ -3025,23 +3053,29 @@
       "dev": true
     },
     "whatwg-encoding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
-      "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.13"
+        "iconv-lite": "0.4.19"
       }
     },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
+    },
     "whatwg-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.1.0.tgz",
-      "integrity": "sha1-X8gnm5PXVIO5ztiyYjmFSEehhXg=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
         "lodash.sortby": "4.7.0",
-        "tr46": "0.0.3",
-        "webidl-conversions": "4.0.1"
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
@@ -3065,10 +3099,20 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "ws": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
     "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/rbuckton/proposal-partial-application#readme",
   "devDependencies": {
     "del": "^2.2.2",
-    "ecmarkup": "^3.11.2",
+    "ecmarkup": "^3.16.0",
     "gulp": "^3.9.1",
     "gulp-emu": "^1.1.0",
     "gulp-live-server": "0.0.30"


### PR DESCRIPTION
This includes the following changes:

* Partial application now specifies eager evaluation. 
  * Arrow functions already provide lazy evaluation.
  * Eager evaluation sidesteps `f({ x: ? })` as sub-expressions cannot be eagerly evaluated. 
* Partial application can no longer be used with `new`.
* Drops the `...` placeholder token, though this may be revisited in a later proposal.
* Clarifies behavior of `f(g(?))`.
* Clarifies that `?` is **not** an expression, merely an extension of the _ArgumentList_ production.
* Clarifies that `x + ?` (or use of `?` in any other arbitrary expression) is not supported.
* Clarifies that `?.f()` is not supported.
* Clarifies that `f(x + ?)` is not supported.

The goal of these changes is to make the proposal more focused and define explicit behavior.

Fixes: #1, #2, #6, #9, #11, #14, #18, #20