### PR TITLE
Update explainer to introduce `~()` for partial application

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
 	"recommendations": [
-		"rbuckton.grammarkdown-language",
 		"rbuckton.ecmarkup-vscode"
 	]
 }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,1065 @@
+# Desugaring Examples
+
+The following document describes approximate desugaring of various partial application scenarios into equivalent ECMAScript code as of ES2021.
+Desugared examples use an IIFE (Immediately Invoked Function Expression) to create temporary values to capture the _callee_, _receiver_,
+and any applied arguments.
+
+## `f~()`
+
+```js
+// source
+const g = f~();
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function () { return _callee(); };
+})();
+```
+
+## `f~(x)`
+
+```js
+// source
+const g = f~(x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied0 = x;
+
+  // partial application
+  return function () { return _callee(_applied0); };
+})();
+```
+
+## `f~(...x)`
+
+```js
+// source
+const g = f~(...x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied0 = [...x];
+
+  // partial application
+  return function () { return _callee(..._applied0); };
+})();
+```
+
+## `f~(?)`
+
+```js
+// source
+const g = f~(?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0) { return _callee(_0); };
+})();
+```
+
+## `f~(?, x)`
+
+```js
+// source
+const g = f~(?, x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0) { return _callee(_0, x); };
+})();
+```
+
+## `f~(x, ?)`
+
+```js
+// source
+const g = f~(x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0) { return _callee(x, _0); };
+})();
+```
+
+## `f~(...x, ?)`
+
+```js
+// source
+const g = f~(x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied0 = [...x];
+
+  // partial application
+  return function (_0) { return _callee(...x, _0); };
+})();
+```
+
+## `f~(?0)`
+
+```js
+// source
+const g = f~(?0);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0) { return _callee(_0); };
+})();
+```
+
+## `f~(?1)`
+
+```js
+// source
+const g = f~(?1);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0 /*unused*/, _1) { return _callee(_1); };
+})();
+```
+
+## `f~(?1, ?)`
+
+```js
+// source
+const g = f~(?1, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0, _1) { return _callee(_1, _0); };
+})();
+```
+
+## `f~(?1, ?0)`
+
+```js
+// source
+const g = f~(?1, ?0);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0, _1) { return _callee(_1, _0); };
+})();
+```
+
+## `f~(?1, x)`
+
+```js
+// source
+const g = f~(?1, x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0 /*unused*/, _1) { return _callee(_1, x); };
+})();
+```
+
+## `f~(...)`
+
+```js
+// source
+const g = f~(...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (..._args) { return _callee(..._args);
+})();
+```
+
+## `f~(x, ...)`
+
+```js
+// source
+const g = f~(x, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied0 = x;
+
+  // partial application
+  return function (..._args) { return _callee(_applied0, ..._args);
+})();
+```
+
+## `f~(..., x)`
+
+```js
+// source
+const g = f~(..., x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied = x;
+
+  // partial application
+  return function (..._args) { return _callee(..._args, _applied); };
+})();
+```
+
+## `f~(?, ...)`
+
+```js
+// source
+const g = f~(?, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0, ..._args) { return _callee(_0, ..._args); };
+})();
+```
+
+## `f~(..., ?)`
+
+```js
+// source
+const g = f~(..., ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0, ..._args) { return _callee(..._args, _0); };
+})();
+```
+
+## `f~(?, x, ...)`
+
+```js
+// source
+const g = f~(?, x, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied = x;
+
+  // partial application
+  return function (_0, ..._args) { return _callee(_0, x, ..._args); };
+})();
+```
+
+## `f~(..., x, ?)`
+
+```js
+// source
+const g = f~(..., x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+  const _applied = x;
+
+  // partial application
+  return function (_0, ..._args) { return _callee(..._args, x, _0); };
+})();
+```
+
+## `f~(?1, ...)`
+
+```js
+// source
+const g = f~(?1, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0 /*unused*/, _1, ..._args) { return _callee(_1, ..._args); };
+})();
+```
+
+## `f~(..., ?1)`
+
+```js
+// source
+const g = f~(..., ?1);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = f;
+
+  // partial application
+  return function (_0 /*unused*/, _1, ..._args) { return _callee(..._args, _1); };
+})();
+```
+
+
+## `o.f~()`
+
+```js
+// source
+const g = o.f~();
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function () { return _callee.call(_receiver); };
+})();
+```
+
+## `o.f~(x)`
+
+```js
+// source
+const g = o.f~(x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied0 = x;
+
+  // partial application
+  return function () { return _callee.call(_receiver, _applied0); };
+})();
+```
+
+## `o.f~(...x)`
+
+```js
+// source
+const g = o.f~(...x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied0 = [...x];
+
+  // partial application
+  return function () { return _callee.call(_receiver, ..._applied0); };
+})();
+```
+
+## `o.f~(?)`
+
+```js
+// source
+const g = o.f~(?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0) { return _callee.call(_receiver, _0); };
+})();
+```
+
+## `o.f~(?, x)`
+
+```js
+// source
+const g = o.f~(?, x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0) { return _callee.call(_receiver, _0, x); };
+})();
+```
+
+## `o.f~(x, ?)`
+
+```js
+// source
+const g = o.f~(x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0) { return _callee.call(_receiver, x, _0); };
+})();
+```
+
+## `o.f~(...x, ?)`
+
+```js
+// source
+const g = o.f~(x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied0 = [...x];
+
+  // partial application
+  return function (_0) { return _callee.call(_receiver, ...x, _0); };
+})();
+```
+
+## `o.f~(?0)`
+
+```js
+// source
+const g = o.f~(?0);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0) { return _callee.call(_receiver, _0); };
+})();
+```
+
+## `o.f~(?1)`
+
+```js
+// source
+const g = o.f~(?1);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0 /*unused*/, _1) { return _callee.call(_receiver, _1); };
+})();
+```
+
+## `o.f~(?1, ?)`
+
+```js
+// source
+const g = o.f~(?1, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0, _1) { return _callee.call(_receiver, _1, _0); };
+})();
+```
+
+## `o.f~(?1, ?0)`
+
+```js
+// source
+const g = o.f~(?1, ?0);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0, _1) { return _callee.call(_receiver, _1, _0); };
+})();
+```
+
+## `o.f~(?1, x)`
+
+```js
+// source
+const g = o.f~(?1, x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0 /*unused*/, _1) { return _callee.call(_receiver, _1, x); };
+})();
+```
+
+## `o.f~(...)`
+
+```js
+// source
+const g = o.f~(...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = o.f;
+
+  // partial application
+  return function (..._args) { return _callee.call(_receiver, ..._args); };
+}
+```
+
+## `o.f~(x, ...)`
+
+```js
+// source
+const g = o.f~(x, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = o.f;
+  const _applied0 = x;
+
+  // partial application
+  return function (..._args) { return _callee.call(_receiver, _applied0, ..._args); };
+}
+```
+
+## `o.f~(..., x)`
+
+```js
+// source
+const g = o.f~(..., x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied = x;
+
+  // partial application
+  return function (..._args) { return _callee.call(_receiver, ..._args, _applied); };
+})();
+```
+
+## `o.f~(?, ...)`
+
+```js
+// source
+const g = o.f~(?, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0, ..._args) { return _callee.call(_receiver, _0, ..._args); };
+})();
+```
+
+## `o.f~(..., ?)`
+
+```js
+// source
+const g = o.f~(..., ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0, ..._args) { return _callee.call(_receiver, ..._args, _0); };
+})();
+```
+
+## `o.f~(?, x, ...)`
+
+```js
+// source
+const g = o.f~(?, x, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied = x;
+
+  // partial application
+  return function (_0, ..._args) { return _callee.call(_receiver, _0, x, ..._args); };
+})();
+```
+
+## `o.f~(..., x, ?)`
+
+```js
+// source
+const g = o.f~(..., x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+  const _applied = x;
+
+  // partial application
+  return function (_0, ..._args) { return _callee.call(_receiver, ..._args, x, _0); };
+})();
+```
+
+## `o.f~(?1, ...)`
+
+```js
+// source
+const g = o.f~(?1, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0 /*unused*/, _1, ..._args) { return _callee.call(_receiver, _1, ..._args); };
+})();
+```
+
+## `o.f~(..., ?1)`
+
+```js
+// source
+const g = o.f~(..., ?1);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _receiver = o;
+  const _callee = _receiver.f;
+
+  // partial application
+  return function (_0 /*unused*/, _1, ..._args) { return _callee.call(_receiver, ..._args, _1); };
+})();
+```
+
+## `new C~()`
+
+```js
+// source
+const g = new C~();
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function () { return new _callee(); };
+})();
+```
+
+## `new C~(x)`
+
+```js
+// source
+const g = new C~(x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied0 = x;
+
+  // partial application
+  return function () { return new _callee(_applied0); };
+})();
+```
+
+## `new C~(...x)`
+
+```js
+// source
+const g = new C~(...x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied0 = [...x];
+
+  // partial application
+  return function () { return new _callee(..._applied0); };
+})();
+```
+
+## `new C~(?)`
+
+```js
+// source
+const g = new C~(?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0) { return new _callee(_0); };
+})();
+```
+
+## `new C~(?, x)`
+
+```js
+// source
+const g = new C~(?, x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0) { return new _callee(_0, x); };
+})();
+```
+
+## `new C~(x, ?)`
+
+```js
+// source
+const g = new C~(x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0) { return new _callee(x, _0); };
+})();
+```
+
+## `new C~(...x, ?)`
+
+```js
+// source
+const g = new C~(x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied0 = [...x];
+
+  // partial application
+  return function (_0) { return new _callee(...x, _0); };
+})();
+```
+
+## `new C~(?0)`
+
+```js
+// source
+const g = new C~(?0);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0) { return new _callee(_0); };
+})();
+```
+
+## `new C~(?1)`
+
+```js
+// source
+const g = new C~(?1);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0 /*unused*/, _1) { return new _callee(_1); };
+})();
+```
+
+## `new C~(?1, ?)`
+
+```js
+// source
+const g = new C~(?1, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0, _1) { return new _callee(_1, _0); };
+})();
+```
+
+## `new C~(?1, ?0)`
+
+```js
+// source
+const g = new C~(?1, ?0);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0, _1) { return new _callee(_1, _0); };
+})();
+```
+
+## `new C~(?1, x)`
+
+```js
+// source
+const g = new C~(?1, x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied0 = x;
+
+  // partial application
+  return function (_0 /*unused*/, _1) { return new _callee(_1, x); };
+})();
+```
+
+## `new C~(...)`
+
+```js
+// source
+const g = new C~(...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (..._args) { return new _callee(..._args); };
+})();
+```
+
+## `new C~(x, ...)`
+
+```js
+// source
+const g = new C~(x, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied0 = x;
+
+  // partial application
+  return function (..._args) { return new _callee(_applied0, ..._args); };
+})();
+```
+
+## `new C~(..., x)`
+
+```js
+// source
+const g = new C~(..., x);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied = x;
+
+  // partial application
+  return function (..._args) { return new _callee(..._args, _applied); };
+})();
+```
+
+## `new C~(?, ...)`
+
+```js
+// source
+const g = new C~(?, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0, ..._args) { return new _callee(_0, ..._args); };
+})();
+```
+
+## `new C~(..., ?)`
+
+```js
+// source
+const g = new C~(..., ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0, ..._args) { return new _callee(..._args, _0); };
+})();
+```
+
+## `new C~(?, x, ...)`
+
+```js
+// source
+const g = new C~(?, x, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied = x;
+
+  // partial application
+  return function (_0, ..._args) { return new _callee(_0, x, ..._args); };
+})();
+```
+
+## `new C~(..., x, ?)`
+
+```js
+// source
+const g = new C~(..., x, ?);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+  const _applied = x;
+
+  // partial application
+  return function (_0, ..._args) { return new _callee(..._args, x, _0); };
+})();
+```
+
+## `new C~(?1, ...)`
+
+```js
+// source
+const g = new C~(?1, ...);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0 /*unused*/, _1, ..._args) { return new _callee(_1, ..._args); };
+})();
+```
+
+## `new C~(..., ?1)`
+
+```js
+// source
+const g = new C~(..., ?1);
+
+// desugared
+const g = (() => {
+  // applied values
+  const _callee = C;
+
+  // partial application
+  return function (_0 /*unused*/, _1, ..._args) { return new _callee(..._args, _1); };
+})();
+```

--- a/README.md
+++ b/README.md
@@ -377,16 +377,7 @@ const slice = Array.prototype.slice.call~(?, ?, ?);
 slice({ 0: "a", 1: "b", length: 2 }, 1, 2); // ["b"]
 ```
 
-<!--
-**F#-style Pipelines**
-```js
-// AST transformation
-const newNode = createFunctionExpression(oldNode.name, visitNodes(oldNode.parameters), visitNode(oldNode.body))
-  |> setOriginalNode(?, oldNode)
-  |> setTextRange(?, oldNode.pos, oldNode.end)
-  |> setEmitFlags(?, EmitFlags.NoComments);
-```
--->
+You can also find a number of desugaring examples in [EXAMPLES.md](EXAMPLES.md).
 
 # Open Questions/Concerns
 
@@ -400,94 +391,6 @@ token's visual meaning best aligns with this proposal, and its fairly easy to wr
 complex expressions today using existing tokens (e.g. `f(+i+++j-i---j)` or `f([[][]][[]])`).
 A valid, clean example of both partial application, optional chaining, and nullish coalesce is
 not actually difficult to read in most cases: `f~(?, a?.b ?? c)`.
-
-<!--
-## Relation to the Pipeline Operator
-
-While useful in its own right, partial application was initially envisioned alongside the 
-pipeline operator (`|>`) as a means of piping the left-hand operand into a specific argument 
-position in a function call on the right-hand operand.
-
-However, there are currently three competing proposals for pipeline:
-
-1. F#-style pipelines (which this proposal favors).
-1. Hack-style pipelines
-1. "Smart mix" pipelines
-
-### F#-style pipelines
-
-An F#-style pipeline is represented by the expression `X |> F`, in which `X` and then `F` are 
-evaluated, and the result of `F(X)` is returned. In general, this is a fairly simple set of
-rules to explain.
-
-Partial application can also be easily explained in terms of `F.bind()`, except that you have 
-more control over which arguments are bound and which are unbound.
-
-These two building blocks can then be used to form more complex expressions. For example, in the
-expression `X |> F(a, ?)`, `X` is evaluated, followed by `F`, and `a`, and then the result of 
-`F(a, X)` is returned.
-
-While F#-style pipelines are easily explained, there are caveats regarding their execution. 
-As they are designed to pipe function calls, other expression forms are not supported without
-leveraging something like an Arrow function. It also requires a special syntactic form to 
-support `await` in the middle of an F#-style pipeline, and `yield`/`yield*` is not supported
-at all.
-
-This proposal heavily favors the F#-style pipeline approach as it complements partial 
-application and is easier to teach both as individual components of the language that can
-be composed together for greater effect.
-
-### Hack-style pipelines
-
-A Hack-style pipeline is represented by the expression `X |> F($)`, in which `X` is evaluated
-and stored in a "topic variable" (in this example, `$`), then `F` is evaluated, and the result
-of `F($)` is returned.
-
-Since the right-hand operand of a Hack-style pipeline can be an arbitrary expression, it is
-farily easy to perform in-situ calculations (i.e. `X |> $ + $`), as well as support operators
-such as `await` and `yield`/`yield*`.
-
-While Hack-style pipelines are very flexible, they do not support tacit, point-free pipelines
-such as `X |> F`, as you must use the topic variable to pass the value. Also, topic variables
-have various caveats. Topic variables that are _also_ valid identifiers can shadow identifiers
-declared in an outer scope. This is problematic as the most common topic variables in other 
-languages are tokens like `$` or `_`, which are both the default names of highly popular
-libraries (i.e. jQuery, underscore, lodash). As such, it is currently in proposal to use a 
-non-identifier token as the topic. 
-
-Topic variables also can be difficult to use if you introduce a nested scope that has the topic 
-variable in scope, especially if you intend to reference an outer topic variable within a 
-pipeline in a nested scope. This complication still arises even when using a non-identifier 
-token as the topic.
-
-Also, Hack-style pipelines are already feasible _without_ introducing new syntax today:
-
-```js
-let $; // Hack-style topic variable
-let result = (
-  $= books,
-  $= filter($, _ => _.title = "..."),
-  $= map($, _ => _.author),
-  $);
-```
-
-### "Smart mix" pipelines
-
-"Smart mix" pipelines are represented by _either_ `X |> F` (where `F` _may not_ have parenthesis), 
-or `X |> F($)`. Smart mix pipelines are designed to support _both_ Hack-style pipelines with a 
-topic variable, as well as tacit point-free pipelines. Smart-mix pipelines would effectively 
-forbid the use of partial application in a pipeline, as any right-hand operand expression with
-parenthesis _must_ use the topic variable. Since `X |> F(1, ?)($)` is unnecessarily verbose,
-it is more likely that users would instead write `X |> F(1, $)`. 
-
-As with Hack-style pipelines the right-hand operand of a Smart mix pipeline can be an arbitrary 
-expression, as long as it uses the topic variable.
-
-Smart mix pipelines suffer from the same caveats as Hack-style pipelines with respect to topic 
-variables, as well as a possible refactoring hazard when refactoring `F` in `X |> F`, into a more
-complex expression as there are certain expression forms which are forbidden in the tacit style and
-require conversion to the topic style.
--->
 
 # Resources
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Partial Application Syntax for ECMAScript
 
-This proposal introduces a new syntax using the `?` token in an argument list which allows you to 
-partially apply an argument list to a call expression by acting as a placeholder for an argument.
+This proposal introduces syntax for a new calling convention (using `~()`) to allow you to
+partially apply an argument list to a call or `new` expression through the use of a placeholder (`?`) 
+as an unbound argument.
 
 ## Status
 
@@ -30,82 +31,183 @@ addOne(2); // 3
 // arrow functions
 const addTen = x => add(x, 10);
 addTen(2); // 12
-
-// arrow functions and pipeline
-const newScore = player.score
-  |> _ => add(7, _)
-  |> _ => clamp(0, 100, _); // deeply nested stack, the pipe to `clamp` is *inside* the previous arrow function.
 ```
 
 However, there are several of limitations with these approaches:
 
 * `bind` can only fix the leading arguments of a function.
 * `bind` requires you explicitly specify the `this` receiver.
-* You cannot easily use `bind` with a template expression or tagged template expression.
-* Arrow functions can be cumbersome when paired with the [pipeline proposal](https://github.com/gilbert/es-pipeline-operator):
-  * Need to write `|> _ =>` for each step in the pipeline.
-  * Unclear as to which stack frame we are in for the call to `clamp`. This can affect available stack space and 
-    is harder to debug.
+* Arrow functions lazily reevaluate their bodies, which can introduce unintended side-effects.
 
-To resolve these concerns, we propose leveraging the `?` token to act as an "argument placeholder" 
-for a non-fixed argument:
+To resolve these concerns, we propose the introduction of a new calling convention using `~()`, 
+leveraging the `?` token to act as an "argument placeholder" for a non-fixed argument, and the
+`...` token to act as a "remaining arguments placeholder" for any excess arguments:
 
 ```js
-const addOne = add(1, ?); // apply from the left
+const addOne = add~(1, ?); // apply from the left
 addOne(2); // 3
 
-const addTen = add(?, 10); // apply from the right
+const addTen = add~(?, 10); // apply from the right
 addTen(2); // 12
 
-// with pipeline
-let newScore = player.score
-  |> add(7, ?)
-  |> clamp(0, 100, ?); // shallow stack, the pipe to `clamp` is the same frame as the pipe to `add`.
-
-// partial template strings
-const Diagnostics = {
-  unexpected_token: `Unexpected token: ${?}`,
-  name_not_found: `'${?}' not found.`
-};
-Diagnostics.name_not_found("foo"); // "'foo' not found."
+[1, 2, 3].forEach(console.log~(?)); // accepts exactly one argument
 ```
 
 # Syntax
 
-The `?` placeholder token can be supplied one or more times at the top level of the _Arguments_ of 
-a _CallExpression_, _CallMemberExpression_, or _SuperCall_ (e.g. `f(?)` or `o.f(?)`), or in place 
-of the _Expression_ of a _TemplateMiddleList_ (e.g. `` f`before${?}after` ``). `?` is **not**
-an expression, rather it is a syntactic element that indicates special behavior (much like how 
-`` `...` AssignmentExpression `` indicates spread, yet is itself not an expression). 
+## The `~()` Partial Application Calling Convention
+
+A partially applied call uses a separate calling convention than a normal call. Instead of using `()`
+to call or construct a value, you initiate a partial call using `~()`. A partially applied call without
+placeholders essentially binds any provided arguments into a new function. If the expression being invoked
+produces a _Reference_, the `this` binding of the _Reference_ is preserved. Excess arguments supplied to 
+the resulting function are ignored.
+
+```js
+const sayNothing = console.log~();
+const sayHi = console.log~("Hello!");
+
+sayNothing();       // prints:
+sayNothing("Shhh"); // prints: 
+
+sayHi();            // prints: Hello!
+
+const bob = {
+  name: "Bob",
+  introduce() {
+    console.log(`Hello, my name is ${this.name}.`);
+  }
+};
+
+const introduceBob = bob.introduce~();
+introduceBob();     // prints: Hello, my name is Bob.
+```
+
+This would not be the first new calling convention in ECMAScript, which also has tagged templates (i.e., `` tag`text${expr}` ``)
+and nullish function evaluation (i.e., `f?.()`).
+
+## The `?` Placeholder Argument
+
+The `?` placeholder token can be supplied one or more times at the top level of the argument list of
+a _CallExpression_, _CallMemberExpression_, or `new` (e.g. `f~(?)` or `o.f~(?)`). `?` is **not**
+an expression, rather it is a syntactic element that indicates special behavior (much like how
+`` `...` AssignmentExpression `` indicates spread, yet is itself not an expression).
 
 ```js
 // valid
-f(x, ?)           // partial application from left
-f(?, x)           // partial application from right
-f(?, x, ?)        // partial application for any arg
-o.f(x, ?)         // partial application from left
-o.f(?, x)         // partial application from right
-o.f(?, x, ?)      // partial application for any arg
-super.f(?)        // partial application allowed for call on |SuperProperty|
+f~(x, ?)          // partial application from left
+f~(?, x)          // partial application from right
+f~(?, x, ?)       // partial application for any arg
+o.f~(x, ?)        // partial application from left
+o.f~(?, x)        // partial application from right
+o.f~(?, x, ?)     // partial application for any arg
+super.f~(?)       // partial application allowed for call on |SuperProperty|
+new C~(?)         // partial application of constructor
 
 // invalid
-f(x + ?)          // `?` not in top-level Arguments of call
+f~(x + ?)         // `?` not in top-level Arguments of call
 x + ?             // `?` not in top-level Arguments of call
-?.f()             // `?` not in top-level Arguments of call
-new f(?)          // `?` not supported in `new`
-super(?)          // `?` not supported in |SuperCall|
+?.f~()            // `?` not in top-level Arguments of call
+super~(?)         // `?` not supported in |SuperCall|
 ```
+
+In addition the `?` placeholder token can be followed by a decimal integer value &ge; 0 indicating a fixed
+ordinal position (i.e., `?0`). Ordinal placeholders can be repeated multiple times within a partial application,
+but still point to the same unbound argument. If a partial application contains a mix of non-ordinal placeholders 
+and ordinal placeholders, the non-ordinal placeholders are implicitly numbered to fill in any gaps:
+
+```js
+const printArgs = (a = "a", b = "b", c = "c") => console.log(`${a}, ${b}, ${c}`);
+printArgs();                            // prints: a, b, c
+printArgs(1, 2, 3);                     // prints: 1, 2, 3
+
+const swapAC = printArgs~(?2, ?, ?0);
+swapAC(1, 2, 3);                        // prints: 3, 2, 1
+
+const ignoreBC = printArgs~(?2);
+ignoreBC(1);                            // prints: 1, b, c
+```
+
+Ordinal placeholders are especially useful for adapting callbacks that expect arguments in a different order:
+
+```js
+const printAB = (a, b) => console.log(`${a}, ${b}`);
+const acceptBA = (cb) => cb("b", "a");
+acceptBA(printAB~(?1, ?0));             // prints: a, b
+```
+
+## Fixed Arity
+
+By default, partial application uses a fixed argument list: Normal arguments are evaluated and bound
+to their respective argument position, and placeholder (`?`) arguments and Ordinal placeholder (`?0`, etc.)
+arguments are bound to specific argument positions in the resulting partially applied function. As a result,
+excess arguments passed to a partially applied function have no specific position in which they should be 
+inserted. While this behavior differs from `f.bind()`, a fixed argument list allows us to avoid unintentionally
+accepting excess arguments:
+
+```js
+// (a)
+[1, 2, 3].forEach(console.log.bind(console, "element:"));
+// prints:
+// element: 1 0 1,2,3
+// element: 2 1 1,2,3
+// element: 3 2 1,2,3
+
+// (b)
+[1, 2, 3].forEach(x => console.log("element:", x));
+// prints:
+// element: 1
+// element: 2
+// element: 3
+
+// (c)
+[1, 2, 3].forEach(console.log~("element:", ?));
+// prints:
+// element: 1
+// element: 2
+// element: 3
+```
+
+In the example above, (a) prints extraneous information due to the fact that `forEach` not only passes the
+value of each element as an argument, but also the ordinal index of the element and the array in which the 
+element is contained.
+
+In the case of (b), the arrow function has a fixed arity. No matter how many excess arguments are passed to
+the callback, only the `x` parameter is forwarded onto the call.
+
+The intention of partial application is to emulate a normal call like `console.log("element:", 1)`, where 
+evaluation of the "applied" portions occurs eagerly with only the placeholders being "unapplied". This means 
+that excess arguments have no place to go as part of evaluation. As a result, (c) behaves similar to (b) in 
+that only a single argument is accepted by the partial function application and passed through to `console.log`.
+
+## Variable Arity: Pass Through Remaining Arguments using `...` 
+
+However, sometimes you may need the variable arity of something like `f.bind()`. To support this, partial
+application includes a `...` placeholder token with a specific meaning: Take the _rest_ of the arguments
+supplied to the partial function and _spread_ them into this position:
+
+```js
+const writeLog = (header, ...args) => console.log(header, ...args);
+const writeAppLog = writeLog~("[app]", ...);
+writeAppLog("Hello", "World!");             // prints: [app] Hello World!
+
+const writeAppLogWithBreak = writeAppLog~(..., "\n---\n");
+writeAppLogWithBreak("End of section");     // prints: [app] End of section\n---\n
+```
+
+A partially applied call may only have a single `...` in its argument list, though it may spread in other arguments
+using `...expr` as you might in a normal call.
 
 # Semantics
 
-The `?` placeholder token can only be used in an argument list of a call expression, or as the only
-token in a placeholder of a template expression or tagged template expression. When present, the 
-result of the call is a new function with a parameter for each `?` token in the argument list. 
-Any non-placeholder expression in the argument list becomes fixed in its position. This is 
+A call or `new` expression that uses the `~()` calling convention results in a partially applied call. The result
+is a new function with a parameter for each placeholder (i.e., `?`, `?0`, etc.) in the argument list. If
+the partial call contains a `...` placeholder token, a rest parameter is added as the final parameter of the
+new function. Any non-placeholder expression in the argument list becomes fixed in their positions. This is 
 illustrated by the following syntactic conversion:
 
 ```js
-const g = f(?, 1, ?);
+const g = f~(?, 1, ?);
 ```
 
 is roughly identical in its behavior to:
@@ -118,29 +220,12 @@ const g = (() => {
 })();
 ```
 
-As well, with template expressions:
+In addition to fixing the function to be called and its explicit arguments, we also fix the callee and
+any supplied _receiver_ as part of the resulting function. As such, `o.f~(?)` will maintain `o` as the 
+`this` receiver when calling `o.f`. This can be illustrated by the following syntactic conversion:
 
 ```js
-const g = f`${?},${1},${?}`;
-```
-
-is roughly identical in its behavior to:
-
-```js
-const g = (() => {
-  const fn = f;
-  const tpl = /* template site object for `${?},${1},${?}` */;
-  return (a0, a1) => fn(p0, a0, tpl, a1);
-})();
-```
-
-In addition to fixing the function to be called and its explicit arguments, we also fix any 
-supplied _receiver_ as part of the resulting function, as we will store the Reference in the 
-resulting function. As such, `o.f(?)` will maintain `o` as the `this` receiver when calling `o.f`. 
-This can be illustrated by the following syntactic conversion:
-
-```js
-const g = o.f(?, 1);
+const g = o.f~(?, 1);
 ```
 
 is roughly identical in its behavior to:
@@ -148,35 +233,36 @@ is roughly identical in its behavior to:
 ```js
 const g = (() => {
   const receiver = o;
-  const fn = o.f;
+  const fn = receiver.f;
   const p0 = 1;
   return (a0) => fn.call(receiver, a0, p0);
 })();
 ```
 
-In both of the above examples, excess supplied arguments to `g` are ignored and **not** passed on 
-to the partially applied function. The ability to pass on additional arguments is not part of this
-proposal but may be considered in a future proposal.
-
 The following is a list of additional semantic rules:
 
-* Given `f(?)`, the expression `f` is evaluated immediately.
-* Given `f(?, x)`, the non-placeholder argument `x` is evaluated immediately and fixed in its position.
-* Given `f(?)`, excess arguments supplied to the partially applied function result are ignored.
-* Given `f(?, ?)` the partially applied function result will have a parameter for each placeholder 
+* Given `f~(?)`, the expression `f` is evaluated immediately.
+* Given `f~(?, x)`, the non-placeholder argument `x` is evaluated immediately and fixed in its position.
+* Given `f~(?)`, excess arguments supplied to the partially applied function result are ignored.
+* Given `f~(?, ?)` the partially applied function result will have a parameter for each placeholder 
   token that is supplied in that token's position in the argument list.
-* Given `f(this, ?)`, the `this` in the argument list is the lexical `this`.
-* Given `f(?)`, the `this` receiver of the function `f` is fixed as `undefined` in the partially
+* Given `f~(this, ?)`, the `this` in the argument list is the lexical `this`.
+* Given `f~(?)`, the `this` receiver of the function `f` is fixed as `undefined` in the partially
   applied function result.
-* Given `f(?)`, the `length` of the partially applied function result is equal to the number of `?` placeholder tokens in the
+* Given `f~(?)`, the `length` of the partially applied function result is equal to the number of `?` placeholder tokens in the
   argument list.
-* Given `f(?)`, the `name` of the partially applied function result is `f.name`.
-* Given `o.f(?)`, the references to `o` and `o.f` are evaluated immediately.
-* Given `o.f(?)`, the `this` receiver of the function `o.f` is fixed as `o` in the partially 
+* Given `f~(?)`, the `name` of the partially applied function result is `f.name`.
+* Given `o.f~(?)`, the references to `o` and `o.f` are evaluated immediately.
+* Given `o.f~(?)`, the `this` receiver of the function `o.f` is fixed as `o` in the partially 
   applied function result.
-* Given `f(g(?))`, the result is equivalent to `f(_0 => g(_0))` **not** `_0 => f(g(_0))`. This 
+* Given `f(g~(?))`, the result is roughly equivalent to `f(_0 => g(_0))` **not** `_0 => f(g(_0))`. This 
   is because the `?` is directly part of the argument list of `g` and not the argument list of `f`.
+* Given `new C~()`, the result is a function that returns a new instance of `C`.
+  * NOTE: This is not easily achievable with `.bind()` today (if at all).
+* Given `new (f~())`, the partial application of `f` returns a new function that can be constructed via `new`, similar
+  to `new (f.bind(null))`.
 
+<!--
 ## Pipeline and Partial Application
 
 This proposal is designed to dove-tail into the pipeline operator (`|>`) proposal as a way to interop 
@@ -214,22 +300,18 @@ is approximately identical to:
 let $$temp;
 const res = ($$temp = a, $$temp = f($$temp, 1), g($$temp, 2));
 ```
+-->
 
 # Parsing
 
 While this proposal leverages the existing `?` token used in conditional expressions, it does not
 introduce parsing ambiguity as the `?` placeholder token can only be used in an argument list and 
-cannot have an expression immediately preceding it (e.g. `f(a?` is definitely a conditional 
-while `f(?` is definitely a placeholder).
+cannot have an expression immediately preceding it (e.g. `f~(a?` is definitely a conditional 
+while `f~(?` is definitely a placeholder).
 
 # Grammar
 
 ```grammarkdown
-TemplateMiddleList[Yield, Await, Tagged] :
-  TemplateMiddle `?`
-  TemplateMiddle Expression[+In, ?Yield, ?Await]
-  TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateMiddle Expression[+In, ?Yield, ?Await]
-
 MemberExpression[Yield, Await] :
   `new` MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await, ~Partial]
 
@@ -237,7 +319,7 @@ CallExpression[Yield, Await] :
   CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await, +Partial]
 
 CoverCallExpressionAndAsyncArrowHead[Yield, Await]:
-  MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await, +Partial
+  MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await, +Partial]
 
 CallMemberExpression[Yield, Await] :
   MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await, +Partial]
@@ -246,36 +328,42 @@ SuperCall[Yield, Await] :
   `super` Arguments[?Yield, ?Await, ~Partial]
 
 Arguments[Yield, Await, Partial] :
-  `(` ArgumentList[?Yield, ?Await, ?Partial] `)`
-  `(` ArgumentList[?Yield, ?Await, ?Partial], `,` `)`
+  `(` ArgumentList[?Yield, ?Await, ~Partial] `)`
+  `(` ArgumentList[?Yield, ?Await, ~Partial], `,` `)`
+  [+Partial] [no LineTerminator here] `~` `(` ArgumentList[?Yield, ?Await, +Partial] `)`
+  [+Partial] [no LineTerminator here] `~` `(` ArgumentList[?Yield, ?Await, +Partial] `,` `)`
 
 ArgumentList[Yield, Await, Partial] :
   AssignmentExpression[+In, ?Yield, ?Await]
   `...` AssignmentExpression[+In, ?Yield, ?Await]
   ArgumentList[?Yield, ?Await, ?Partial] `,` AssignmentExpression[+In, ?Yield, ?Await]
   ArgumentList[?Yield, ?Await, ?Partial] `,` `...` AssignmentExpression[+In, ?Yield, ?Await]
-  [+Partial] `?`
-  [+Partial] ArgumentList[?Yield, ?Await, ?Partial] `,` `?`
+  [+Partial] `?` DecimalDigits?
+  [+Partial] `...`
+  [+Partial] ArgumentList[?Yield, ?Await, ?Partial] `,` `?` DecimalDigits?
+  [+Partial] ArgumentList[?Yield, ?Await, ?Partial] `,` `...`
 ```
+
+> NOTE: It is a **SyntaxError** for a partial call to have more than one `...` placeholder.
 
 # Examples
 
 **Logging with Timestamps**
 ```js
-const log = console.log({ toString() { return `[${new Date()}]` } }, ?);
+const log = console.log~({ toString() { return `[${new Date()}]` } }, ?);
 log("test"); // [2018-07-17T23:25:36.984Z] test
 ```
 
 **Event Handlers**
 ```js
-button.addEventListener("click", this.onClick(?));
+button.addEventListener("click", this.onClick~(?));
 ```
 
 **Bound methods**
 ```js
 class Collator {
   constructor() {
-    this.compare = this.compare(?, ?);
+    this.compare = this.compare~(?, ?);
   }
   compare(a, b) { ... }
 }
@@ -286,15 +374,16 @@ class Collator {
 // doWork expects a callback of `(err, value) => void`
 function doWork(callback) { ... }
 function onWorkCompleted(err, value, state) { ... }
-doWork(onWorkCompleted(?, ?, { key: "value" }));
+doWork(onWorkCompleted~(?, ?, { key: "value" }));
 ```
 
 **Uncurry `this`**
 ```js
-const slice = Array.prototype.slice.call(?, ?, ?);
+const slice = Array.prototype.slice.call~(?, ?, ?);
 slice({ 0: "a", 1: "b", length: 2 }, 1, 2); // ["b"]
 ```
 
+<!--
 **F#-style Pipelines**
 ```js
 // AST transformation
@@ -303,80 +392,22 @@ const newNode = createFunctionExpression(oldNode.name, visitNodes(oldNode.parame
   |> setTextRange(?, oldNode.pos, oldNode.end)
   |> setEmitFlags(?, EmitFlags.NoComments);
 ```
+-->
 
 # Open Questions/Concerns
-
-## The "garden path" 
-
-Partial application is an example of a "garden path" syntax, in that as you start to read 
-`f(a, b(), c, ?)` from left to right it initially looks like a regular _CallExpression_.
-It is not until you reach the final `?` argument that it becomes clear that this is a partial 
-application of the function `f`. 
-
-One suggestion to solve this would be to have some sort of prefix token to indicate that the call 
-is, in fact, partial. This is under consideration at this time, however we currently feel that this
-is an unnecessary syntactic burden. There already exists two other cases in ECMAScript that exhibit
-this "garden path" behavior: Arrow functions and Assignment patterns. Both of these features 
-provided a new capabilities for the development community and have already become well understood
-and heavily adopted features. As such, we believe that partial application is also a sufficiently
-powerful new capability that more than compensates for the "garden path" concern.
-
-## Support for `new`
-
-Currently, partial application is not supported for `new`. This is more a matter of determining 
-the best semantics for this behavior. Currently we are considering allowing partial application
-of `new` as resulting in a function that _also_ must be called with `new`:
-
-```js
-const f = new Point(?, 10);
-const obj1 = f(20);     // TypeError
-const obj2 = new f(20); // OK
-```
-
-However, we have not yet settled on this behavior and have decided to forbid usage in `new` at 
-this time.
-
-## Support for rest/spread (`...`)
-
-At this time rest/spread (`...`) has been removed from this proposal to be considered as a future
-revision.
-
-Previously, this proposal allowed `...` as a placeholder, which indicated that the _rest_ of the
-unbound arguments should be _spread_ in this position:
-
-```js
-function f(a, b, c, d) { console.log(`a: ${a}, b: ${b}, c: ${c}, d: ${d}`); }
-const g = f(?, 1, ...);
-g(2);       // a: 2, b: 1, c: undefined, d: undefined
-g(2, 3);    // a: 2, b: 1, c: 3, d: undefined
-g(2, 3, 4); // a: 2, b: 1, c: 3, d: 4
-```
-
-However, there was some confusion and concern about using `...` twice in an argument list, 
-as well as how to get the _rest_ of the arguments as an array instead of spreading them.
-
-This is a feature we may revisit as a follow in proposal in the future. In the mean time,
-Arrow functions are a feasible alternative.
-
-## Support for "receiver" placeholder
-
-There have been several discussions related to partial application and the ability to
-bind the receiver in an expression, i.e. `X |> ?.foo()`. This is not a feature we are 
-pursuing at this time as it greatly expands the syntax complexity (need to find `?` in
-any expression, rather than just in _ArgumentList_), and runs afoul of visual ambiguity
-with the optional chaining proposal.
 
 ## Choosing a different token than `?`
 
 There have been suggestions to consider another token aside from `?`, given that optional
 chaining may be using `?.` and nullish coalesce may be using `??`. It is our opinion that
 such a token change is unnecessary, as `?` may _only_ be used on its on in an argument list
-and _may not_ be combined with these operators (e.g. `f(??.a??c)` is not legal). The `?`
+and _may not_ be combined with these operators (e.g. `f~(??.a ?? c)` is not legal). The `?`
 token's visual meaning best aligns with this proposal, and its fairly easy to write similarly
 complex expressions today using existing tokens (e.g. `f(+i+++j-i---j)` or `f([[][]][[]])`).
 A valid, clean example of both partial application, optional chaining, and nullish coalesce is
-not actually difficult to read in most cases: `f(?, a?.b ?? c)`.
+not actually difficult to read in most cases: `f~(?, a?.b ?? c)`.
 
+<!--
 ## Relation to the Pipeline Operator
 
 While useful in its own right, partial application was initially envisioned alongside the 
@@ -462,6 +493,7 @@ Smart mix pipelines suffer from the same caveats as Hack-style pipelines with re
 variables, as well as a possible refactoring hazard when refactoring `F` in `X |> F`, into a more
 complex expression as there are certain expression forms which are forbidden in the tacit style and
 require conversion to the topic style.
+-->
 
 # Resources
 


### PR DESCRIPTION
This make the following changes to the proposal:
- Adds a `~` prefix to denote a partially applied argument list (i.e., `f~(?, x)`).
- Adds `?0` ordinal placeholders.
- Adds a `...` "rest of the arguments" placeholder.
- Allows use of partial application with `new`.
- Removes partial application with template literals and tagged templates.
- Removes (or rather, comments out for the time being) references to the pipeline operator.

Fixes #48
Fixes #43 
Fixes #5